### PR TITLE
Unterstützung für iOS 3.x Geräte

### DIFF
--- a/server/php/includes/main.php
+++ b/server/php/includes/main.php
@@ -32,6 +32,7 @@ class iOSUpdater
     // define URL type parameter values
     const TYPE_PROFILE = 'profile';
     const TYPE_APP     = 'app';
+    const TYPE_IPA     = 'ipa';
     
     // define keys for the returning json string
     const RETURN_RESULT   = 'result';
@@ -92,7 +93,7 @@ class iOSUpdater
     
     protected function validateType($type)
     {
-        if (in_array($type, array(self::TYPE_PROFILE, self::TYPE_APP)))
+        if (in_array($type, array(self::TYPE_PROFILE, self::TYPE_APP, self::TYPE_IPA)))
         {
             return $type;
         }
@@ -161,6 +162,16 @@ class iOSUpdater
             $plist_content = file_get_contents($plist);
             header('content-type: application/xml');
             echo str_replace('__URL__', $ipa_url, $plist_content);
+
+        } else if ($type == self::TYPE_IPA) {
+
+            // send latest profile for the given bundleidentifier
+            $filename = $appDirectory  . $ipa;
+            header('Content-Disposition: attachment; filename=' . urlencode(basename($filename)));
+            header('Content-Type: application/octet-stream;');
+            header('Content-Transfer-Encoding: binary');
+            header('Content-Length: '.filesize($filename).";\n");
+            readfile($filename);
 
         }
 

--- a/server/php/public/index.php
+++ b/server/php/public/index.php
@@ -1,5 +1,5 @@
 <?php 
-    require '../includes/main.php';
+    require '/home/iphone/includes/main.php';
     $ios = new iOSUpdater(dirname(__FILE__).DIRECTORY_SEPARATOR);
     $baseURL = "http://".$_SERVER['SERVER_NAME'].$_SERVER['REQUEST_URI'];
 ?>
@@ -90,6 +90,10 @@
                     </div>
                     <div class="info">
                         Use the Install buttons to either install the provisioning profile or the application.
+                    </div>
+
+		    <div style="margin: 10px;">
+                        <a href="<?php echo $baseURL . 'index.php?type=' . iOSUpdater::TYPE_IPA . '&bundleidentifier=' . $app[iOSUpdater::INDEX_DIR] ?>" class="grayButton">Download Application (IPA for iOS 3.x)</a>
                     </div>
 
                 </div>


### PR DESCRIPTION
Hallo Andreas,

wie ich sehe, bist du Deutscher, daher schreibe ich in Deutsch. Sollte das nicht stimmen, kann ich auch nochmal auf Englisch schreiben.

Ich verwende Hockey seit gestern und finde es sehr praktisch. Allerdings nutze ich es auch für die iPad Version meiner App und die Beta-Tester haben noch kein 4.2 installiert. Aber es gab keinen Link auf die IPA-Datei, den diese Tester nutzen könnten.

Daher habe ich einen neuen Button hinzugefügt und den Typ 'ipa' definiert. Schau's dir an. Ich würde mich freuen, wenn du meinen Request annimmst.

Viele Grüße,
Christain
