### PR TITLE
minor change in the "Install Profile" link composition to make Hockey compatible with hosters like 1and1

### DIFF
--- a/server/php/public/index.php
+++ b/server/php/public/index.php
@@ -64,7 +64,7 @@
                     </div>
                     <div class="ipadbuttons">
                 <?php if ($app[iOSUpdater::INDEX_PROFILE]) { ?>                    
-                        <a class="button" href="<?php echo $app[iOSUpdater::INDEX_PROFILE] ?>">Install Profile</a>
+                        <a class="button" href="<?php echo $baseURL . 'index.php?type=' . iOSUpdater::TYPE_PROFILE . '&bundleidentifier=' . $app[iOSUpdater::INDEX_DIR] ?>">Install Profile</a>
                 <?php } ?>
                         <a class="button" href="itms-services://?action=download-manifest&amp;url=<?php echo urlencode($baseURL . 'index.php?type=' . iOSUpdater::TYPE_APP . '&bundleidentifier=' . $app[iOSUpdater::INDEX_DIR]) ?>">Install Application</a>
                     </div>
@@ -137,7 +137,7 @@
                     <p><b>Version:</b> <?php echo $app[iOSUpdater::INDEX_VERSION] ?></p>
                     <p><b>Released:</b> <?php echo date('m/d/Y H:i:s', $app[iOSUpdater::INDEX_DATE]) ?></p>
                 <?php if ($app[iOSUpdater::INDEX_PROFILE]) { ?>                    
-                    <a class="button" href="<?php echo $app[iOSUpdater::INDEX_PROFILE] ?>">Install Profile</a>
+                    <a class="button" href="<?php echo $baseURL . 'index.php?type=' . iOSUpdater::TYPE_PROFILE . '&bundleidentifier=' . $app[iOSUpdater::INDEX_DIR] ?>">Install Profile</a>
                 <?php } ?>
                     <a class="button" href="itms-services://?action=download-manifest&amp;url=<?php echo urlencode($baseURL . 'index.php?type=' . iOSUpdater::TYPE_APP . '&bundleidentifier=' . $app[iOSUpdater::INDEX_DIR]) ?>">Install Application</a>
                 <?php if ($app[iOSUpdater::INDEX_NOTES]) : ?>


### PR DESCRIPTION
When I tried to install Hockey on a 1und1 web space the installation link does not work. 
Therefore I just used the profile download link as the profile installation link and tested the installation link with the following devices: 
iPhone 4 with iOS 4.1 (8B117) ... worked perfectly
iPad with iOS 4.2 GM ... worked perfectly

Maybe the small change is quite suitable for all the other too.

BTW ... Hockey is gorgeous ... and a perfect way to solve the AdHoc-Betatester-Distribution gap.
