### PR TITLE
iPhone Simulator instead of i386

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 .DS_Store
+*.ipa
 *.swp
 *~.nib
 
 build/
 
+*.mode?v3
 *.pbxuser
 *.perspective
 *.perspectivev3

--- a/server/php/includes/main.php
+++ b/server/php/includes/main.php
@@ -170,6 +170,9 @@ class iOSUpdater
         $platform = $device;
         
         switch ($device) {
+            case "i386":
+                $platform = "iPhone Simulator";
+                break;
             case "iPhone1,1":
                 $platform = "iPhone";
                 break;


### PR DESCRIPTION
Extended main.php to replace i386 by iPhone simulator.
