### PR TITLE
Add a "readfile_chunked" function to send big ipa file

### DIFF
--- a/server/php/includes/main.php
+++ b/server/php/includes/main.php
@@ -27,6 +27,33 @@
 require('json.inc');
 require('plist.inc');
 
+define('CHUNK_SIZE', 1024*1024); // Size (in bytes) of tiles chunk
+
+  // Read a file and display its content chunk by chunk
+  function readfile_chunked($filename, $retbytes = TRUE) {
+    $buffer = '';
+    $cnt =0;
+    // $handle = fopen($filename, 'rb');
+    $handle = fopen($filename, 'rb');
+    if ($handle === false) {
+      return false;
+    }
+    while (!feof($handle)) {
+      $buffer = fread($handle, CHUNK_SIZE);
+      echo $buffer;
+      ob_flush();
+      flush();
+      if ($retbytes) {
+        $cnt += strlen($buffer);
+      }
+    }
+    $status = fclose($handle);
+    if ($retbytes && $status) {
+      return $cnt; // return num. bytes delivered like readfile() does.
+    }
+    return $status;
+}
+
 function nl2br_skip_html($string)
 {
 	// remove any carriage returns (Windows)
@@ -323,7 +350,7 @@ class iOSUpdater
             header('Content-Type: application/octet-stream;');
             header('Content-Transfer-Encoding: binary');
             header('Content-Length: '.filesize($filename).";\n");
-            readfile($filename);
+            readfile_chunked($filename);
         }
 
         exit();


### PR DESCRIPTION
I had problem to distribute big ipa file, because php script load in RAM the file.
But most php configurations have limited size in RAM memory.

I found the "readfile_chunked" function on the site:
http://teddy.fr/blog/how-serve-big-files-through-php

I replace the default "readfile" for ipa file by this methods, and it works perfectly.

I wish you'll accept it :)
