### PR TITLE
Wrong lineBreakMode

### DIFF
--- a/client/iOS/Helper/PSAppStoreHeader.m
+++ b/client/iOS/Helper/PSAppStoreHeader.m
@@ -115,7 +115,7 @@
     
     // sub
     [secondaryTextColor set];
-    [subHeaderLabel drawAtPoint:CGPointMake(kTextRow, kImageMargin+kImageHeight-12) forWidth:globalWidth-kTextRow withFont:smallFont lineBreakMode:UIBaselineAdjustmentNone];
+    [subHeaderLabel drawAtPoint:CGPointMake(kTextRow, kImageMargin+kImageHeight-12) forWidth:globalWidth-kTextRow withFont:smallFont lineBreakMode:UILineBreakModeTailTruncation];
     
     CGColorRelease(myColor);
     CGColorSpaceRelease(myColorSpace);


### PR DESCRIPTION
XCode 4.1 complained about a wrong assignment to UILabel lineBreakMode. Fixed with same lineBreakMode as used by the other UILabels in PSAppStoreHeader
