### PR TITLE
remove popover with its viewController

### DIFF
--- a/client/iOS/BWHockeyViewController.m
+++ b/client/iOS/BWHockeyViewController.m
@@ -389,6 +389,8 @@
 
 - (void)viewWillDisappear:(BOOL)animated {
     self.hockeyManager.currentHockeyViewController = nil;
+    //if the popover is still visible, dismiss it
+    [popOverController_ dismissPopoverAnimated:YES];
     [super viewWillDisappear:animated];
     [[UIApplication sharedApplication] setStatusBarStyle:statusBarStyle_];
 }
@@ -456,6 +458,7 @@
 
 - (void)viewDidUnload {
     [appStoreHeader_ release]; appStoreHeader_ = nil;
+    [popOverController_ release], popOverController_ = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self.hockeyManager removeObserver:self forKeyPath:@"checkInProgress"];
     [self.hockeyManager removeObserver:self forKeyPath:@"isUpdateURLOffline"];


### PR DESCRIPTION
when presenting BWHockeyViewController modally, as
a sheet on the iPad and the "Done" button is pressed,
BWHockeyViewController removes itself from the navigation-
stack but leaves an optionally visible settings popover behind.
This patch dismisses the popover when BWHockeyViewController goes
away.

Besides that, this fixes a memory leak ;)
