### PR TITLE
Fixing of str_replace parameters order. (It didn't work before on Apache 

### DIFF
--- a/server/php/includes/router.php
+++ b/server/php/includes/router.php
@@ -84,7 +84,7 @@ class Router
 
 	    /* Check if HockeyKit is running on a Windows server, if so: update the path variable to let it parse correctly. */
         if( PHP_OS == "WIN32" || PHP_OS == "WINNT" )
-		    $path = str_replace($path, "\\", "/");
+		    $path = str_replace("\\", "/", $path);
 
         if ($path == '/') $path = '';
 


### PR DESCRIPTION
Fixing of str_replace parameters order. (It didn't work before on Apache under Windows with Hockey server in subfolder.)
