### PR TITLE
Add CocoaPods spec.

### DIFF
--- a/HockeyKit.podspec
+++ b/HockeyKit.podspec
@@ -1,0 +1,27 @@
+Pod::Spec.new do |s|
+  s.name     = 'HockeyKit'
+  s.version  = '2.0.3'
+  s.license  = 'MIT'
+  s.platform = :ios
+  s.summary  = 'A software update kit for iOS.'
+  s.homepage = 'http://hockeykit.net/'
+  s.author   = { 'Andreas Linde' => 'mail@andreaslinde.de' }
+  s.source   = { :git => 'https://github.com/TheRealKerni/HockeyKit.git', :tag => '2.0.3' }
+
+  s.description = 'Hockey is a iOS Ad-Hoc updater framework. It can be used for all apps that '        \
+                  'target the Apple AppStore and improves the beta testing process dramatically. '     \
+                  'NOTES: You will need to add a dependency on JSONKit or SBJson yourself. If you '    \
+                  'want the framework to try again when a network is available, add a dependency '     \
+                  'on Reachability and send a notification with the name `NetworkDidBecomeReachable` ' \
+                  'yourself when the network becomse reachable.'
+
+  s.source_files = 'client/iOS',
+                   # TODO this dir contains more vendored code by Peter Steinberger. He said that he would
+                   # move this code out into its own repo in the near future. Add a dependency on that new
+                   # repo when he does.
+                   'client/iOS/Helper'
+
+  s.resource     = 'client/iOS/Hockey.bundle'
+  s.clean_paths  = 'client/Android', 'demo', 'server', 'client/iOS/HockeyLib', 'client/iOS/JSON'
+  s.frameworks   = 'QuartzCore', 'SystemConfiguration'
+end


### PR DESCRIPTION
I recently added [HockeyKit](https://github.com/CocoaPods/Specs/blob/master/HockeyKit/2.0.3/HockeyKit.podspec) to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager.

During this process I did notice a few things that were unclear to a first time user of the framework:
- Either JSONKit or SBJson is required, but the source comes with JSONKit in a JSON directory and the README does not offer anymore insights in what the user should do.
- The README talks about listening to Reachability notifications and the demo Xcode project references Reachability.h and .m. However, it doesn't say anywhere which version of Reachability, or that it doesn't even really matter anymore because you have to send a notification yourself once the network is reachable.

Finally, this pull request adds the pod spec to the repo as well. Adding this will allow users to install an unreleased version directly from your repo. It also allows you to more easily keep the spec up-to-date with any possible changes, instead of having to remember it all when releasing a new version.

HTH,
Thanks!
