### PR TITLE
Add forward declaration for PSAppStoreHeader in BWHockeyViewController

### DIFF
--- a/client/iOS/BWHockeyViewController.h
+++ b/client/iOS/BWHockeyViewController.h
@@ -24,7 +24,6 @@
 
 #import <UIKit/UIKit.h>
 #import "PSStoreButton.h"
-#import "PSAppStoreHeader.h"
 
 typedef enum {
 	AppStoreButtonStateOffline,
@@ -36,6 +35,7 @@ typedef enum {
 
 
 @class BWHockeyManager;
+@class PSAppStoreHeader;
 
 @interface BWHockeyViewController : UITableViewController <PSStoreButtonDelegate> {
     BWHockeyManager *hockeyManager_;

--- a/client/iOS/BWHockeyViewController.m
+++ b/client/iOS/BWHockeyViewController.m
@@ -28,6 +28,7 @@
 #import "BWHockeyManager.h"
 #import "BWGlobal.h"
 #import "UIImage+HockeyAdditions.h"
+#import "PSAppStoreHeader.h"
 #import "PSWebTableViewCell.h"
 #import "BWHockeySettingsViewController.h"
 


### PR DESCRIPTION
This is to work around a problem with header imports when importing HockeyKit via CocoaPods.
