### PR TITLE
removed "-diff -merge" for pbxprojs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.pbxproj -crlf -diff -merge


### PR DESCRIPTION
While it might not be the best idea to let git merge
changes in pbxprojs, it can at least try and show
diffs for them.
Since this was the only change in .gitattributes, the
file was removed from the repository
