### PR TITLE
Changed deployment target to 5.0

### DIFF
--- a/client/iOS/HockeyLib/HockeyLib.xcodeproj/project.pbxproj
+++ b/client/iOS/HockeyLib/HockeyLib.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 				GCC_PREFIX_HEADER = HockeyLib_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = HOCKEYLIB_STATIC_LIBRARY;
 				INSTALL_PATH = /usr/local/lib;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = HockeyLib;
 			};
 			name = Debug;
@@ -273,6 +274,7 @@
 				GCC_PREFIX_HEADER = HockeyLib_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = HOCKEYLIB_STATIC_LIBRARY;
 				INSTALL_PATH = /usr/local/lib;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = HockeyLib;
 			};
 			name = Release;


### PR DESCRIPTION
This fix is necessary so that the static library can be built and used as subproject of any app that has support for iOS 5.0.
