### PR TITLE
Fix analyze warning

### DIFF
--- a/client/iOS/BWHockeySettingsViewController.m
+++ b/client/iOS/BWHockeySettingsViewController.m
@@ -264,6 +264,7 @@
 }
 
 - (void)viewDidUnload {
+    [super viewDidUnload];
   // Relinquish ownership of anything that can be recreated in viewDidLoad or on demand.
   // For example: self.myOutlet = nil;
 }


### PR DESCRIPTION
Fixed warning: The 'viewDidUnload' instance method in UIViewController
subclass 'BWHockeySettingsViewController' is missing a [super
viewDidUnload] call
